### PR TITLE
 use getOffsetTimestamp instead of getTimestamp from sale start WP_Date

### DIFF
--- a/app/PriorPrice/HistoryStorage.php
+++ b/app/PriorPrice/HistoryStorage.php
@@ -79,9 +79,9 @@ class HistoryStorage {
 		}
 
 		if ( $count_from === 'sale_start_inclusive' ) {
-			$sale_start_timestamp = $sale_start->getTimestamp()  + DAY_IN_SECONDS;
+			$sale_start_timestamp = $sale_start->getOffsetTimestamp()  + DAY_IN_SECONDS;
 		} else {
-			$sale_start_timestamp = $sale_start->getTimestamp();
+			$sale_start_timestamp = $sale_start->getOffsetTimestamp();
 		}
 
 		$history = $this->get_history( $wc_product->get_id() );

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Track WooCommerce Products prior prices history and display the lowest price in the last 30 days (fully configurable). This plugin allows your WC shop to be compliant with European Commission Directive 98/6/EC Article 6a which specifies price reduction announcement policy.
  * Author: Konrad Karpieszuk
  * Author URI: https://wpzlecenia.pl
- * Version: 2.1
+ * Version: {VERSION}
  * Text Domain: wc-price-history
  * Domain Path: /languages/
  * Requires at least: 5.8

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ Please submit the [GitHub issue](https://github.com/kkarpieszuk/wc-price-history
 
 = {VERSION} =
 * Fixed: Reverted change #89 from 2.1
+* Fixed: Price selection for sale start was comparing saved historicial timestamps in GMT0 with timestamp of the sale start with local offset (#96)
 
 = 2.1 =
 * New: Additional public methods for external integrations. (#91)

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: omnibus, WooCommerce, prices, history, 30days, lowest
 Requires at least: 5.8
 Tested up to: 6.6.1
 Requires PHP: 7.2
-Stable tag: 2.1
+Stable tag: {VERSION}
 License: MIT License
 License URI: https://mit-license.org/
 Donate link: https://buycoffee.to/wpzlecenia


### PR DESCRIPTION
Fixes #96