### PR TITLE
 extract replace version number to separate script

### DIFF
--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -2,30 +2,8 @@
 
 set -e
 
-function replace_version_number() {
-
-  # Function to traverse directories and replace {VERSION} with the real version number
-  traverse_and_replace() {
-    for file in "$1"/*; do
-      if [ -d "$file" ]; then
-        # Skip /vendor and /node_modules directories
-        if [[ "$file" == */vendor ]] || [[ "$file" == */node_modules ]]; then
-          continue
-        fi
-        # Recursively traverse directories
-        traverse_and_replace "$file"
-      elif [ -f "$file" ]; then
-        # Replace {VERSION} with the real version number in files
-        sed -i "s/{VERSION}/$VERSION/g" "$file"
-      fi
-    done
-  }
-
-  # Start traversal from the current working directory
-  traverse_and_replace "."
-
-  echo "Replaced {VERSION} with $VERSION in all files."
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/replace-version.sh"
 
 # take the branch name from the command line argument. If not specified, default to develop.
 BRANCH=${1:-develop}

--- a/.scripts/replace-version.sh
+++ b/.scripts/replace-version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Can be sourced (to use replace_version_number) or run standalone.
+# Standalone usage: ./replace-version.sh [VERSION]
+#   Run from the directory where {VERSION} should be replaced (e.g. plugin root or build/gitversion).
+#   If VERSION is omitted, it is read from readme.txt in the current directory.
+
+function replace_version_number() {
+
+  # Function to traverse directories and replace {VERSION} with the real version number
+  traverse_and_replace() {
+    for file in "$1"/*; do
+      if [ -d "$file" ]; then
+        # Skip /vendor and /node_modules directories
+        if [[ "$file" == */vendor ]] || [[ "$file" == */node_modules ]]; then
+          continue
+        fi
+        # Recursively traverse directories
+        traverse_and_replace "$file"
+      elif [ -f "$file" ]; then
+        # Replace {VERSION} with the real version number in files
+        sed -i "s/{VERSION}/$VERSION/g" "$file"
+      fi
+    done
+  }
+
+  # Start traversal from the current working directory
+  traverse_and_replace "."
+
+  echo "Replaced {VERSION} with $VERSION in all files."
+}
+
+# When run directly (not sourced), get VERSION and run replace_version_number
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  VERSION="${1:-}"
+  if [ -z "$VERSION" ]; then
+    if [ ! -f "readme.txt" ]; then
+      echo "Error: readme.txt not found in current directory. Run from plugin root or pass VERSION as first argument." >&2
+      exit 1
+    fi
+    VERSION=$(grep -oP '(?<=Stable tag: ).*' readme.txt)
+  fi
+  replace_version_number
+fi

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: omnibus, WooCommerce, prices, history, lowest
 Requires at least: 5.8
 Tested up to: 6.9
 Requires PHP: 7.2
-Stable tag: {VERSION}
+Stable tag: 3.0.0
 License: Expat
 License URI: https://mit-license.org/
 Donate link: https://buycoffee.to/wpzlecenia


### PR DESCRIPTION
fixes #172 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to build/release scripting and a readme version tag; runtime plugin code is unaffected.
> 
> **Overview**
> Build/version placeholder replacement is extracted from `.scripts/build.sh` into a new reusable `.scripts/replace-version.sh`, and `build.sh` now sources it instead of defining the function inline.
> 
> The new script can also be run standalone (optionally taking `VERSION` or deriving it from `readme.txt`) to replace `{VERSION}` across the working tree while skipping `vendor` and `node_modules`.
> 
> `readme.txt` is updated to set `Stable tag` to `3.0.0` instead of `{VERSION}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1339cb9c5eda516d174415a2c9452890255e9be9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->