### PR TITLE
 version always top

### DIFF
--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -61,7 +61,7 @@ rm -rf .git .github .husky .scripts node_modules \
  README.md screenshot-1.png docs pr
 
 replace_version_number
-
+replace_version_always_top
 
 # create a zip file.
 zip -r ../wc-price-history.zip .

--- a/.scripts/replace-version.sh
+++ b/.scripts/replace-version.sh
@@ -32,6 +32,28 @@ function replace_version_number() {
   echo "Replaced {VERSION} with $VERSION in all files."
 }
 
+# Replaces {VERSION_ALWAYS_TOP} with current version. For use only in release process (e.g. build.sh).
+# In repo files keep {VERSION_ALWAYS_TOP}; it is replaced only during build, not committed.
+function replace_version_always_top() {
+
+  traverse_and_replace_always_top() {
+    for file in "$1"/*; do
+      if [ -d "$file" ]; then
+        if [[ "$file" == */vendor ]] || [[ "$file" == */node_modules ]]; then
+          continue
+        fi
+        traverse_and_replace_always_top "$file"
+      elif [ -f "$file" ]; then
+        sed -i "s/{VERSION_ALWAYS_TOP}/$VERSION/g" "$file"
+      fi
+    done
+  }
+
+  traverse_and_replace_always_top "."
+
+  echo "Replaced {VERSION_ALWAYS_TOP} with $VERSION in all files."
+}
+
 # When run directly (not sourced), get VERSION and run replace_version_number
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   VERSION="${1:-}"


### PR DESCRIPTION
fixes #175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script-only change that affects packaged output via string substitution; low risk but could impact published artifacts if the placeholder matches unintended text.
> 
> **Overview**
> Updates the release build process to also replace a new `{VERSION_ALWAYS_TOP}` placeholder with the current plugin version when generating the distributable.
> 
> Adds `replace_version_always_top` to `.scripts/replace-version.sh` and invokes it from `.scripts/build.sh` after the existing `{VERSION}` replacement, while still skipping `vendor` and `node_modules` during traversal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 762c6cc24eff58403efe2ed811a85d631d679ad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->