### PR TITLE
 lowest price now excludes sale start moment

### DIFF
--- a/app/PriorPrice/HistoryStorage.php
+++ b/app/PriorPrice/HistoryStorage.php
@@ -152,11 +152,16 @@ class HistoryStorage {
 
 		$history = $this->get_history( $wc_product->get_id() );
 
+		// For "sale_start" (exclude promotional price) use strict < so we only consider history before sale started.
+		$include_sale_start = ( $count_from === 'sale_start_inclusive' );
+
 		// Get only $days last items.
 		$the_last = array_filter(
 			$history,
-			static function( $timestamp ) use ( $days, $sale_start_timestamp ) {
-				return $timestamp >= ( $sale_start_timestamp - ( $days * DAY_IN_SECONDS ) ) && $timestamp <= $sale_start_timestamp;
+			static function( $timestamp ) use ( $days, $sale_start_timestamp, $include_sale_start ) {
+				$in_range = $timestamp >= ( $sale_start_timestamp - ( $days * DAY_IN_SECONDS ) );
+				$before_end = $include_sale_start ? ( $timestamp <= $sale_start_timestamp ) : ( $timestamp < $sale_start_timestamp );
+				return $in_range && $before_end;
 			},
 			ARRAY_FILTER_USE_KEY
 		);

--- a/app/PriorPrice/HistoryStorageTable.php
+++ b/app/PriorPrice/HistoryStorageTable.php
@@ -89,6 +89,9 @@ class HistoryStorageTable {
 		$sale_start_date = gmdate( 'Y-m-d H:i:s', $sale_start_timestamp_utc );
 		$cutoff_date     = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp_utc );
 
+		// For "sale_start" (exclude promotional price) use strict < so we only consider history before sale started.
+		$end_op = ( $count_from === 'sale_start_inclusive' ) ? '<=' : '<';
+
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
@@ -98,7 +101,7 @@ class HistoryStorageTable {
 				FROM {$wpdb->prefix}wc_price_history
 				WHERE product_id = %d
 				AND date_gmt >= %s
-				AND date_gmt <= %s
+				AND date_gmt {$end_op} %s
 				AND include_in_history = 1
 				AND price > 0",
 				$wc_product->get_id(),

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,9 @@ Yes, I am available for hire. Please contact me at [LinkedIn](https://linkedin.c
 == Changelog ==
 
 = {VERSION_ALWAYS_TOP} =
+- Fix: "Day before product went on sale" – lowest price now excludes sale start moment (was showing promotional price). (#192)
+
+= 3.2.2 =
 - Fix: Custom DB tables – when saving the first price for a product, save it for the current moment and for 24h and 48h earlier so "lowest price in 30 days" has data from day one. Use NULL for sale_price when not set (not 0). (#188)
 - Pro: Promotional widget for Pro version. (#190)
 


### PR DESCRIPTION
fixes #192

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts core lowest-price calculation around sale boundaries, which can change compliance-visible pricing output for on-sale products. Logic is small and localized but affects both legacy and table-based history paths.
> 
> **Overview**
> Fixes the *"Day before product went on sale"* calculation so the lowest-price window ends **strictly before** `sale_start` (using `<` instead of `<=`), preventing the promotional price recorded at the sale start moment from being considered.
> 
> Applies the boundary change consistently in both the legacy post-meta history filter (`HistoryStorage::get_minimal_from_sale_start`) and the custom table query (`HistoryStorageTable::get_minimal_from_sale_start`), and documents the fix in `readme.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8543e344e6f6dcd852dbf7904647331033ee7025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->