### PR TITLE
 show regular if no history

### DIFF
--- a/app/PriorPrice/Prices.php
+++ b/app/PriorPrice/Prices.php
@@ -146,7 +146,12 @@ class Prices {
 		$count_from  = $this->settings_data->get_count_from();
 
 		if ( in_array( $count_from, [ 'sale_start', 'sale_start_inclusive' ] ) && $wc_product->is_on_sale() ) {
-			return $this->history_storage->get_minimal_from_sale_start( $wc_product, $days_number, $count_from );
+			$minimal = $this->history_storage->get_minimal_from_sale_start( $wc_product, $days_number, $count_from );
+			// For "sale_start" (exclude promotional), when no history before sale exists, use regular price as "lowest before discount".
+			if ( $count_from === 'sale_start' && (float) $minimal <= 0 ) {
+				return (float) $wc_product->get_regular_price();
+			}
+			return $minimal;
 		}
 
 		return (float) $this->history_storage->get_minimal( $wc_product->get_id(), $days_number );

--- a/app/PriorPrice/Shortcode.php
+++ b/app/PriorPrice/Shortcode.php
@@ -109,6 +109,10 @@ class Shortcode {
 
 		if ( in_array( $count_from, [ 'sale_start', 'sale_start_inclusive' ] ) && $product->is_on_sale() ) {
 			$lowest = $this->history_storage->get_minimal_from_sale_start( $product, $days_number, $count_from );
+			// For "sale_start" (exclude promotional), when no history before sale exists, use regular price.
+			if ( $count_from === 'sale_start' && (float) $lowest <= 0 ) {
+				$lowest = (float) $product->get_regular_price();
+			}
 		} else {
 			$lowest = $this->history_storage->get_minimal( $id, $days_number );
 		}


### PR DESCRIPTION
Fixes #192 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lowest-price calculation shown to customers during sales when using `sale_start`, which can affect price disclosures and storefront output. Logic is small but touches core pricing display paths.
> 
> **Overview**
> When `count_from` is `sale_start` and a product is on sale, the plugin now **falls back to the product’s regular price** if `get_minimal_from_sale_start()` returns no usable pre-sale history (<= 0).
> 
> This behavior is applied consistently in both the main price display (`Prices::get_lowest_price_raw_non_taxed`) and the `[wc_price_history]` shortcode output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a547f70d493054e9369c53c0fc2820634d71fab0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->