### PR TITLE
Fix sale-start lowest price when pre-sale window has no history.

### DIFF
--- a/app/PriorPrice/HistoryStorage.php
+++ b/app/PriorPrice/HistoryStorage.php
@@ -156,34 +156,26 @@ class HistoryStorage {
 		$include_sale_start = ( $count_from === 'sale_start_inclusive' );
 		$cutoff_timestamp   = $sale_start_timestamp - ( $days * DAY_IN_SECONDS );
 
-		$is_before_sale_end = static function ( int $timestamp ) use ( $sale_start_timestamp, $include_sale_start ): bool {
-			return $include_sale_start
+		$window_prices = [];
+		$older_prices  = [];
+
+		foreach ( $history as $timestamp => $price ) {
+			$before_sale_end = $include_sale_start
 				? ( $timestamp <= $sale_start_timestamp )
 				: ( $timestamp < $sale_start_timestamp );
-		};
 
-		// Get only $days last items.
-		$the_last = array_filter(
-			$history,
-			static function ( $timestamp ) use ( $cutoff_timestamp, $is_before_sale_end ) {
-				return $timestamp >= $cutoff_timestamp && $is_before_sale_end( $timestamp );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
+			if ( ! $before_sale_end ) {
+				continue;
+			}
 
-		if ( ! empty( $the_last ) ) {
-			return $this->reduce_to_minimal( $the_last );
+			if ( $timestamp >= $cutoff_timestamp ) {
+				$window_prices[ $timestamp ] = $price;
+			} else {
+				$older_prices[ $timestamp ] = $price;
+			}
 		}
 
-		$before_window = array_filter(
-			$history,
-			static function ( $timestamp ) use ( $cutoff_timestamp, $is_before_sale_end ) {
-				return $timestamp < $cutoff_timestamp && $is_before_sale_end( $timestamp );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
-
-		return $this->reduce_to_minimal( $before_window );
+		return $this->reduce_to_minimal( ! empty( $window_prices ) ? $window_prices : $older_prices );
 	}
 
 	/**

--- a/app/PriorPrice/HistoryStorage.php
+++ b/app/PriorPrice/HistoryStorage.php
@@ -154,14 +154,19 @@ class HistoryStorage {
 
 		// For "sale_start" (exclude promotional price) use strict < so we only consider history before sale started.
 		$include_sale_start = ( $count_from === 'sale_start_inclusive' );
+		$cutoff_timestamp   = $sale_start_timestamp - ( $days * DAY_IN_SECONDS );
+
+		$is_before_sale_end = static function ( int $timestamp ) use ( $sale_start_timestamp, $include_sale_start ): bool {
+			return $include_sale_start
+				? ( $timestamp <= $sale_start_timestamp )
+				: ( $timestamp < $sale_start_timestamp );
+		};
 
 		// Get only $days last items.
 		$the_last = array_filter(
 			$history,
-			static function( $timestamp ) use ( $days, $sale_start_timestamp, $include_sale_start ) {
-				$in_range = $timestamp >= ( $sale_start_timestamp - ( $days * DAY_IN_SECONDS ) );
-				$before_end = $include_sale_start ? ( $timestamp <= $sale_start_timestamp ) : ( $timestamp < $sale_start_timestamp );
-				return $in_range && $before_end;
+			static function ( $timestamp ) use ( $cutoff_timestamp, $is_before_sale_end ) {
+				return $timestamp >= $cutoff_timestamp && $is_before_sale_end( $timestamp );
 			},
 			ARRAY_FILTER_USE_KEY
 		);
@@ -170,14 +175,10 @@ class HistoryStorage {
 			return $this->reduce_to_minimal( $the_last );
 		}
 
-		$cutoff_timestamp = $sale_start_timestamp - ( $days * DAY_IN_SECONDS );
-
 		$before_window = array_filter(
 			$history,
-			static function( $timestamp ) use ( $cutoff_timestamp, $sale_start_timestamp, $include_sale_start ) {
-				$before_cutoff = $timestamp < $cutoff_timestamp;
-				$before_end    = $include_sale_start ? ( $timestamp <= $sale_start_timestamp ) : ( $timestamp < $sale_start_timestamp );
-				return $before_cutoff && $before_end;
+			static function ( $timestamp ) use ( $cutoff_timestamp, $is_before_sale_end ) {
+				return $timestamp < $cutoff_timestamp && $is_before_sale_end( $timestamp );
 			},
 			ARRAY_FILTER_USE_KEY
 		);

--- a/app/PriorPrice/HistoryStorage.php
+++ b/app/PriorPrice/HistoryStorage.php
@@ -166,7 +166,23 @@ class HistoryStorage {
 			ARRAY_FILTER_USE_KEY
 		);
 
-		return $this->reduce_to_minimal( $the_last );
+		if ( ! empty( $the_last ) ) {
+			return $this->reduce_to_minimal( $the_last );
+		}
+
+		$cutoff_timestamp = $sale_start_timestamp - ( $days * DAY_IN_SECONDS );
+
+		$before_window = array_filter(
+			$history,
+			static function( $timestamp ) use ( $cutoff_timestamp, $sale_start_timestamp, $include_sale_start ) {
+				$before_cutoff = $timestamp < $cutoff_timestamp;
+				$before_end    = $include_sale_start ? ( $timestamp <= $sale_start_timestamp ) : ( $timestamp < $sale_start_timestamp );
+				return $before_cutoff && $before_end;
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+
+		return $this->reduce_to_minimal( $before_window );
 	}
 
 	/**

--- a/app/PriorPrice/HistoryStorageTable.php
+++ b/app/PriorPrice/HistoryStorageTable.php
@@ -110,7 +110,28 @@ class HistoryStorageTable {
 			)
 		);
 
-		return (float) ( $result ?? 0.0 );
+		if ( $result !== null ) {
+			return (float) $result;
+		}
+
+		// Window is empty: use the lowest price recorded before the window (still before sale start).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$fallback = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT MIN(price)
+				FROM {$wpdb->prefix}wc_price_history
+				WHERE product_id = %d
+				AND date_gmt < %s
+				AND date_gmt {$end_op} %s
+				AND include_in_history = 1
+				AND price > 0",
+				$wc_product->get_id(),
+				$cutoff_date,
+				$sale_start_date
+			)
+		);
+
+		return (float) ( $fallback ?? 0.0 );
 	}
 
 	/**

--- a/app/PriorPrice/HistoryStorageTable.php
+++ b/app/PriorPrice/HistoryStorageTable.php
@@ -90,50 +90,17 @@ class HistoryStorageTable {
 		$cutoff_date     = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp_utc );
 
 		// For "sale_start" (exclude promotional price) use strict < so we only consider history before sale started.
-		$end_op = ( $count_from === 'sale_start_inclusive' ) ? '<=' : '<';
+		$end_op     = ( $count_from === 'sale_start_inclusive' ) ? '<=' : '<';
+		$product_id = $wc_product->get_id();
 
-		global $wpdb;
-
-		// Two-step lookup: first the configured period before sale start, then older history.
-		// Kept as separate queries because the fallback is rare (no edits in the window) and the
-		// primary query stays a simple indexed MIN on the usual date range.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$result = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT MIN(price)
-				FROM {$wpdb->prefix}wc_price_history
-				WHERE product_id = %d
-				AND date_gmt >= %s
-				AND date_gmt {$end_op} %s
-				AND include_in_history = 1
-				AND price > 0",
-				$wc_product->get_id(),
-				$cutoff_date,
-				$sale_start_date
-			)
-		);
+		// Two-step lookup: configured period first, then older history when the window is empty.
+		$result = $this->query_min_price_before_sale_start( $product_id, $cutoff_date, $sale_start_date, $end_op, '>=' );
 
 		if ( $result !== null ) {
 			return (float) $result;
 		}
 
-		// Window is empty: use the lowest price recorded before the window (still before sale start).
-		// Only reached when the query above returns NULL, so most requests never run this one.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$fallback = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT MIN(price)
-				FROM {$wpdb->prefix}wc_price_history
-				WHERE product_id = %d
-				AND date_gmt < %s
-				AND date_gmt {$end_op} %s
-				AND include_in_history = 1
-				AND price > 0",
-				$wc_product->get_id(),
-				$cutoff_date,
-				$sale_start_date
-			)
-		);
+		$fallback = $this->query_min_price_before_sale_start( $product_id, $cutoff_date, $sale_start_date, $end_op, '<' );
 
 		return (float) ( $fallback ?? 0.0 );
 	}
@@ -522,6 +489,52 @@ class HistoryStorageTable {
 		$gmt_offset_hours = (float) get_option( 'gmt_offset' );
 
 		return (int) round( $gmt_offset_hours * HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Query MIN(price) for a product within a date range before sale start.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @param int    $product_id      Product ID.
+	 * @param string $cutoff_date     Cutoff date (Y-m-d H:i:s UTC).
+	 * @param string $sale_start_date Sale start date (Y-m-d H:i:s UTC).
+	 * @param string $end_op          Comparison before sale start ('<' or '<=').
+	 * @param string $cutoff_op       Comparison against cutoff ('>=' or '<').
+	 *
+	 * @return string|null MIN price as string, or null when no matching rows.
+	 */
+	private function query_min_price_before_sale_start(
+		int $product_id,
+		string $cutoff_date,
+		string $sale_start_date,
+		string $end_op,
+		string $cutoff_op
+	): ?string {
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT MIN(price)
+				FROM {$wpdb->prefix}wc_price_history
+				WHERE product_id = %d
+				AND date_gmt {$cutoff_op} %s
+				AND date_gmt {$end_op} %s
+				AND include_in_history = 1
+				AND price > 0",
+				$product_id,
+				$cutoff_date,
+				$sale_start_date
+			)
+		);
+
+		if ( $result === null ) {
+			return null;
+		}
+
+		return (string) $result;
 	}
 
 	/**

--- a/app/PriorPrice/HistoryStorageTable.php
+++ b/app/PriorPrice/HistoryStorageTable.php
@@ -94,6 +94,9 @@ class HistoryStorageTable {
 
 		global $wpdb;
 
+		// Two-step lookup: first the configured period before sale start, then older history.
+		// Kept as separate queries because the fallback is rare (no edits in the window) and the
+		// primary query stays a simple indexed MIN on the usual date range.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$result = $wpdb->get_var(
 			$wpdb->prepare(
@@ -115,6 +118,7 @@ class HistoryStorageTable {
 		}
 
 		// Window is empty: use the lowest price recorded before the window (still before sale start).
+		// Only reached when the query above returns NULL, so most requests never run this one.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$fallback = $wpdb->get_var(
 			$wpdb->prepare(

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -306,6 +306,8 @@ For Omnibus-style display, set sale dates in WooCommerce for each discounted pro
 
 When the setting is **Day before product went on sale**, the plugin calculates the lowest price in the configured period before the sale start moment and excludes the promotional price at the sale start.
 
+If that 30-day window has no stored price changes (for example, the product was not edited for a long time), the plugin uses the lowest price from older history that is still before the sale start, instead of showing the "no price change" fallback message.
+
 If an on-sale product has no sale start date, the plugin falls back to counting from the current day and logs the product in **WooCommerce -> Status -> Logs** with a source starting with `wc-price-history`.
 
 For variable products, set price history inputs on each variation. The parent variable product does not have its own sale dates in the same way variations do.

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -306,7 +306,7 @@ For Omnibus-style display, set sale dates in WooCommerce for each discounted pro
 
 When the setting is **Day before product went on sale**, the plugin calculates the lowest price in the configured period before the sale start moment and excludes the promotional price at the sale start.
 
-If that 30-day window has no stored price changes (for example, the product was not edited for a long time), the plugin uses the lowest price from older history that is still before the sale start, instead of showing the "no price change" fallback message.
+If that configured period before the sale has no stored price changes (for example, the product was not edited for a long time), the plugin uses the lowest price from older history that is still before the sale start, instead of showing the "no price change" fallback message.
 
 If an on-sale product has no sale start date, the plugin falls back to counting from the current day and logs the product in **WooCommerce -> Status -> Logs** with a source starting with `wc-price-history`.
 

--- a/readme.txt
+++ b/readme.txt
@@ -135,7 +135,7 @@ Yes, I am available for hire. Please contact me at [LinkedIn](https://linkedin.c
 = {VERSION_ALWAYS_TOP} =
 - Enhancement: Optional WooCommerce REST API fields `wc_price_history.lowest` and `wc_price_history.history` (settings under WooCommerce → Price History, off by default). (#202)
 - Enhancement: More data in exported JSON file (#195)
-- Fix: When counting from sale start, if the 30-day window before the sale has no history entries (e.g. no product edits for a long time), use the lowest price from older history still before the sale start. (#208)
+- Fix: When counting from sale start, if the configured period before the sale has no history entries (e.g. no product edits for a long time), use the lowest price from older history still before the sale start. (#208)
 - Compatibility: Added compatibility with WooCommerce Product Bundles plugin: if bundled products are priced individually, it was not taken into account when stored Bundle Product in history. Requires WC Price History Pro 1.0.1 or later. (#145)
 
 = 3.2.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ Yes, I am available for hire. Please contact me at [LinkedIn](https://linkedin.c
 = {VERSION_ALWAYS_TOP} =
 - Enhancement: Optional WooCommerce REST API fields `wc_price_history.lowest` and `wc_price_history.history` (settings under WooCommerce → Price History, off by default). (#202)
 - Enhancement: More data in exported JSON file (#195)
+- Fix: When counting from sale start, if the 30-day window before the sale has no history entries (e.g. no product edits for a long time), use the lowest price from older history still before the sale start. (#208)
 - Compatibility: Added compatibility with WooCommerce Product Bundles plugin: if bundled products are priced individually, it was not taken into account when stored Bundle Product in history. Requires WC Price History Pro 1.0.1 or later. (#145)
 
 = 3.2.3 =

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -140,7 +140,7 @@ class HistoryStorageTest extends TestCase {
 	/**
 	 * @dataProvider data_provider_get_minimal_from_sale_start_fallback
 	 */
-	public function test_get_minimal_from_sale_start_falls_back_before_window( $history, $expected_minimal ) {
+	public function test_get_minimal_from_sale_start_falls_back_before_window( $history, $expected_minimal, $count_from ) {
 
 		$product_id = 1;
 		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
@@ -156,7 +156,7 @@ class HistoryStorageTest extends TestCase {
 		$minimal = $subject->get_minimal_from_sale_start(
 			$this->mock_product_with_sale_start( $product_id, $sale_start_timestamp ),
 			30,
-			'sale_start'
+			$count_from
 		);
 
 		$this->assertEquals( $expected_minimal, $minimal );
@@ -165,7 +165,7 @@ class HistoryStorageTest extends TestCase {
 	/**
 	 * @dataProvider data_provider_table_get_minimal_from_sale_start_fallback
 	 */
-	public function test_table_get_minimal_from_sale_start_falls_back_before_window( $primary_min_price, $fallback_min_price, $expected_minimal ) {
+	public function test_table_get_minimal_from_sale_start_falls_back_before_window( $primary_min_price, $fallback_min_price, $expected_minimal, $count_from ) {
 
 		$product_id           = 1;
 		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
@@ -178,7 +178,7 @@ class HistoryStorageTest extends TestCase {
 		$minimal = $subject->get_minimal_from_sale_start(
 			$this->mock_product_with_sale_start( $product_id, $sale_start_timestamp ),
 			30,
-			'sale_start'
+			$count_from
 		);
 
 		$this->assertEquals( $expected_minimal, $minimal );
@@ -289,17 +289,26 @@ class HistoryStorageTest extends TestCase {
 			$cutoff_timestamp + DAY_IN_SECONDS => 59.99,
 		];
 
+		$history_with_sale_start_day_entry = $history_only_before_window + [
+			$sale_start_timestamp => 49.99,
+		];
+
 		return [
-			'empty window falls back to lowest before cutoff' => [ $history_only_before_window, 44.99 ],
-			'non-empty window does not use fallback'          => [ $history_with_entry_in_window, 59.99 ],
+			'empty window falls back to lowest before cutoff' => [ $history_only_before_window, 44.99, 'sale_start' ],
+			'non-empty window does not use fallback'          => [ $history_with_entry_in_window, 59.99, 'sale_start' ],
+			'inclusive empty window falls back to lowest before cutoff' => [ $history_only_before_window, 44.99, 'sale_start_inclusive' ],
+			'inclusive entry on sale start day stays in window' => [ $history_with_sale_start_day_entry, 49.99, 'sale_start_inclusive' ],
+			'sale start excludes entry on sale start day' => [ $history_with_sale_start_day_entry, 44.99, 'sale_start' ],
 		];
 	}
 
 	public function data_provider_table_get_minimal_from_sale_start_fallback() {
 
 		return [
-			'empty window falls back to lowest before cutoff' => [ null, '44.99', 44.99 ],
-			'non-empty window does not use fallback'          => [ '59.99', '44.99', 59.99 ],
+			'empty window falls back to lowest before cutoff' => [ null, '44.99', 44.99, 'sale_start' ],
+			'non-empty window does not use fallback'          => [ '59.99', '44.99', 59.99, 'sale_start' ],
+			'inclusive empty window falls back to lowest before cutoff' => [ null, '44.99', 44.99, 'sale_start_inclusive' ],
+			'inclusive non-empty window does not use fallback' => [ '49.99', '44.99', 49.99, 'sale_start_inclusive' ],
 		];
 	}
 

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -162,6 +162,28 @@ class HistoryStorageTest extends TestCase {
 		$this->assertEquals( $expected_minimal, $minimal );
 	}
 
+	/**
+	 * @dataProvider data_provider_table_get_minimal_from_sale_start_fallback
+	 */
+	public function test_table_get_minimal_from_sale_start_falls_back_before_window( $primary_min_price, $fallback_min_price, $expected_minimal ) {
+
+		$product_id           = 1;
+		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
+
+		$this->mock_table_wpdb_for_sale_start( $primary_min_price, $fallback_min_price );
+		$this->mock_gmt_offset();
+
+		$subject = new HistoryStorageTable();
+
+		$minimal = $subject->get_minimal_from_sale_start(
+			$this->mock_product_with_sale_start( $product_id, $sale_start_timestamp ),
+			30,
+			'sale_start'
+		);
+
+		$this->assertEquals( $expected_minimal, $minimal );
+	}
+
 	private function mock_legacy_storage(): HistoryStorage {
 
 		\WP_Mock::userFunction( 'get_option', [
@@ -180,6 +202,51 @@ class HistoryStorageTest extends TestCase {
 		] );
 
 		return $this->get_subject();
+	}
+
+	private function mock_gmt_offset(): void {
+
+		\WP_Mock::userFunction( 'get_option', [
+			'args' => [ 'gmt_offset' ],
+			'return' => 0,
+		] );
+	}
+
+	/**
+	 * @param string|null $primary_min_price  MIN(price) in the sale-start window, or null when empty.
+	 * @param string|null $fallback_min_price MIN(price) before the window, or null when empty.
+	 */
+	private function mock_table_wpdb_for_sale_start( ?string $primary_min_price, ?string $fallback_min_price ): void {
+
+		global $wpdb;
+		$wpdb = new class( $primary_min_price, $fallback_min_price ) {
+			public $prefix = 'wp_';
+
+			private ?string $primary_min_price;
+
+			private ?string $fallback_min_price;
+
+			public function __construct( ?string $primary_min_price, ?string $fallback_min_price ) {
+				$this->primary_min_price   = $primary_min_price;
+				$this->fallback_min_price  = $fallback_min_price;
+			}
+
+			public function prepare( $query, ...$args ) {
+				return sprintf( $query, ...$args );
+			}
+
+			public function get_var( $query ) {
+				if ( stripos( $query, 'date_gmt >=' ) !== false ) {
+					return $this->primary_min_price;
+				}
+
+				if ( stripos( $query, 'SELECT MIN(price)' ) !== false ) {
+					return $this->fallback_min_price;
+				}
+
+				return null;
+			}
+		};
 	}
 
 	private function mock_product_with_sale_start( int $product_id, int $sale_start_timestamp ): \WC_Product {
@@ -225,6 +292,14 @@ class HistoryStorageTest extends TestCase {
 		return [
 			'empty window falls back to lowest before cutoff' => [ $history_only_before_window, 44.99 ],
 			'non-empty window does not use fallback'          => [ $history_with_entry_in_window, 59.99 ],
+		];
+	}
+
+	public function data_provider_table_get_minimal_from_sale_start_fallback() {
+
+		return [
+			'empty window falls back to lowest before cutoff' => [ null, '44.99', 44.99 ],
+			'non-empty window does not use fallback'          => [ '59.99', '44.99', 59.99 ],
 		];
 	}
 

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -137,6 +137,97 @@ class HistoryStorageTest extends TestCase {
 		$this->assertEquals( 1, $result );
 	}
 
+	/**
+	 * @dataProvider data_provider_get_minimal_from_sale_start_fallback
+	 */
+	public function test_get_minimal_from_sale_start_falls_back_before_window( $history, $expected_minimal ) {
+
+		$product_id = 1;
+		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
+
+		$subject = $this->mock_legacy_storage();
+
+		\WP_Mock::userFunction( 'get_post_meta', [
+			'times' => 1,
+			'args' => [ $product_id, '_wc_price_history', true ],
+			'return' => $history,
+		] );
+
+		$minimal = $subject->get_minimal_from_sale_start(
+			$this->mock_product_with_sale_start( $product_id, $sale_start_timestamp ),
+			30,
+			'sale_start'
+		);
+
+		$this->assertEquals( $expected_minimal, $minimal );
+	}
+
+	private function mock_legacy_storage(): HistoryStorage {
+
+		\WP_Mock::userFunction( 'get_option', [
+			'args' => [ 'wc_price_history_migration_status', \WP_Mock\Functions::type( 'string' ) ],
+			'return' => 'not_needed',
+		] );
+
+		\WP_Mock::userFunction( 'get_option', [
+			'args' => [ 'gmt_offset' ],
+			'return' => 0,
+		] );
+
+		\WP_Mock::userFunction( 'get_option', [
+			'args' => [ 'wc_price_history_migration_status' ],
+			'return' => 'not_needed',
+		] );
+
+		return $this->get_subject();
+	}
+
+	private function mock_product_with_sale_start( int $product_id, int $sale_start_timestamp ): \WC_Product {
+
+		$sale_start = new class( $sale_start_timestamp ) {
+			private int $timestamp;
+
+			public function __construct( int $timestamp ) {
+				$this->timestamp = $timestamp;
+			}
+
+			public function getOffsetTimestamp(): int {
+				return $this->timestamp;
+			}
+		};
+
+		$product = $this->getMockBuilder( \WC_Product::class )
+			->disableOriginalConstructor()
+			->addMethods( [ 'get_id', 'get_date_on_sale_from' ] )
+			->getMock();
+		$product->method( 'get_id' )
+			->willReturn( $product_id );
+		$product->method( 'get_date_on_sale_from' )
+			->willReturn( $sale_start );
+
+		return $product;
+	}
+
+	public function data_provider_get_minimal_from_sale_start_fallback() {
+
+		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
+		$cutoff_timestamp     = $sale_start_timestamp - ( 30 * DAY_IN_SECONDS );
+
+		$history_only_before_window = [
+			strtotime( '2025-06-23 10:00:00' ) => 44.99,
+			strtotime( '2025-11-04 01:00:00' ) => 59.99,
+		];
+
+		$history_with_entry_in_window = $history_only_before_window + [
+			$cutoff_timestamp + DAY_IN_SECONDS => 59.99,
+		];
+
+		return [
+			'empty window falls back to lowest before cutoff' => [ $history_only_before_window, 44.99 ],
+			'non-empty window does not use fallback'          => [ $history_with_entry_in_window, 59.99 ],
+		];
+	}
+
 	public function data_provider_get_minimal() {
 
 		$history = [

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -39,30 +39,14 @@ class HistoryStorageTest extends TestCase {
 
 		$product_id = 1;
 
+		$this->mock_legacy_storage_options();
 		$subject = $this->get_subject();
-
-		// Mock migration status to use post_meta (legacy mode).
-		\WP_Mock::userFunction( 'get_option', [
-			'args' => [ 'wc_price_history_migration_status', \WP_Mock\Functions::type( 'string' ) ],
-			'return' => 'not_needed'
-		] );
 
 		\WP_Mock::userFunction( 'get_post_meta', [
 			'times' => 1,
 			'args' => [ $product_id, '_wc_price_history', true ],
 			'return' => $history
 		] );
-
-		\WP_Mock::userFunction( 'get_option', [
-			'args' => [ 'gmt_offset' ],
-			'return' => 0
-		] );
-
-		\WP_Mock::userFunction( 'get_option', [
-			'args' => [ 'wc_price_history_migration_status' ],
-			'return' => 'not_needed'
-		] );
-
 
 		$minimal = $subject->get_minimal( $product_id, 30 );
 
@@ -76,18 +60,8 @@ class HistoryStorageTest extends TestCase {
 
 		$product_id = 1;
 
+		$this->mock_legacy_storage_options();
 		$subject = $this->get_subject();
-
-		// Mock migration status to use post_meta (legacy mode).
-		\WP_Mock::userFunction( 'get_option', [
-			'args' => [ 'wc_price_history_migration_status', \WP_Mock\Functions::type( 'string' ) ],
-			'return' => 'not_needed'
-		] );
-
-		\WP_Mock::userFunction( 'get_option', [
-			'args' => [ 'gmt_offset' ],
-			'return' => 0
-		] );
 
 		$product = $this->getMockBuilder( 'WC_Product' )
 			->disableOriginalConstructor()
@@ -186,6 +160,13 @@ class HistoryStorageTest extends TestCase {
 
 	private function mock_legacy_storage(): HistoryStorage {
 
+		$this->mock_legacy_storage_options();
+
+		return $this->get_subject();
+	}
+
+	private function mock_legacy_storage_options(): void {
+
 		\WP_Mock::userFunction( 'get_option', [
 			'args' => [ 'wc_price_history_migration_status', \WP_Mock\Functions::type( 'string' ) ],
 			'return' => 'not_needed',
@@ -200,8 +181,6 @@ class HistoryStorageTest extends TestCase {
 			'args' => [ 'wc_price_history_migration_status' ],
 			'return' => 'not_needed',
 		] );
-
-		return $this->get_subject();
 	}
 
 	private function mock_gmt_offset(): void {


### PR DESCRIPTION
Fall back to the lowest recorded price before the 30-day window when counting from sale start and no entries exist in that window.

Fixes #208