### PR TITLE
Fix tax display on fallback prices for simple products and variations

### DIFF
--- a/app/PriorPrice/FrontEndAssets.php
+++ b/app/PriorPrice/FrontEndAssets.php
@@ -27,15 +27,18 @@ class FrontEndAssets {
 		wp_enqueue_style( 'wc-price-history-frontend', WC_PRICE_HISTORY_PLUGIN_URL . 'assets/css/frontend.css', [], '{VERSION_ALWAYS_TOP}' );
 
 		if ( is_product() ) {
-			wp_enqueue_script( 'wc-price-history-frontend', WC_PRICE_HISTORY_PLUGIN_URL . 'assets/js/frontend.js', [ 'jquery' ], '{VERSION_ALWAYS_TOP}', true );
-
-			$price_format = [
-				'thousand_separator' => wc_get_price_thousand_separator(),
-				'decimal_separator'  => wc_get_price_decimal_separator(),
-				'decimals'           => wc_get_price_decimals(),
-			];
-
-			wp_localize_script( 'wc-price-history-frontend', 'wc_price_history_frontend', $price_format );
+			$product = wc_get_product( get_the_ID() );
+			if ( $product && $product->is_type( 'variable' ) ) {
+				wp_enqueue_script( 'wc-price-history-frontend', WC_PRICE_HISTORY_PLUGIN_URL . 'assets/js/frontend.js', [ 'jquery' ], '{VERSION_ALWAYS_TOP}', true );
+	
+				$price_format = [
+					'thousand_separator' => wc_get_price_thousand_separator(),
+					'decimal_separator'  => wc_get_price_decimal_separator(),
+					'decimals'           => wc_get_price_decimals(),
+				];
+	
+				wp_localize_script( 'wc-price-history-frontend', 'wc_price_history_frontend', $price_format );
+			}
 		}
 	}
 }

--- a/app/PriorPrice/Prices.php
+++ b/app/PriorPrice/Prices.php
@@ -314,7 +314,8 @@ class Prices {
 				$wc_product
 			);
 
-			return $this->display_from_template( $price_raw_non_taxed, $days_number, $wc_product );
+			$price_taxed = $this->taxes->apply_taxes( $price_raw_non_taxed, $wc_product );
+			return $this->display_from_template( $price_taxed, $days_number, $wc_product );
 		}
 
 		$old_history_custom_text = $this->settings_data->get_old_history_custom_text();
@@ -322,11 +323,11 @@ class Prices {
 		$old_history_custom_text = str_replace(
 			[ '{price}', '{days}' ],
 			[
-				$this->display_price_value_html( apply_filters(
+				$this->display_price_value_html( $this->taxes->apply_taxes( apply_filters(
 					'wc_price_history_price_raw_non_taxed',
 					(float) $wc_product->get_price(),
 					$wc_product
-				) ),
+				), $wc_product ) ),
 				$days_number
 			],
 			$old_history_custom_text
@@ -365,5 +366,17 @@ class Prices {
 		$display_text = apply_filters( 'wc_price_history_display_from_template', $display_text, $lowest, $days_number );
 
 		return sprintf( '<div class="wc-price-history prior-price lowest" data-product-id="%s" data-original-price="%s"><span class="wc-price-history-lowest-inner">%s</span></div>', $wc_product->get_id(), $lowest, $display_text );
+	}
+
+	/**
+	 * Apply taxes to the price.
+	 *
+	 * @param float       $price
+	 * @param \WC_Product $wc_product
+	 *
+	 * @return float
+	 */
+	public function apply_taxes( float $price, \WC_Product $wc_product ) : float {
+		return $this->taxes->apply_taxes( $price, $wc_product );
 	}
 }

--- a/app/PriorPrice/Variations.php
+++ b/app/PriorPrice/Variations.php
@@ -57,7 +57,7 @@ class Variations {
 
 		if ( $lowest <= 0 ) {
 			$current_price = $variation->get_price();
-			$lowest = $current_price > 0 ? $current_price : 0;
+			$lowest = $current_price > 0 ? $this->prices->apply_taxes( (float) $current_price, $variation ) : 0;
 		}
 
 		/**

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -34,6 +34,7 @@ WCPriceHistory.Frontend = WCPriceHistory.Frontend || ( function( document, windo
 
 			$( 'form.variations_form' ).on( 'found_variation', app.methods.onFoundVariation );
 			$( 'form.variations_form' ).on( 'reset_data', app.methods.onResetData );
+			$( 'form.variations_form' ).trigger( 'check_variations' );
 		},
 
 		/**


### PR DESCRIPTION
Problem: When WooCommerce is configured to enter prices exclusive of tax but display them inclusive of tax on the storefront, the lowest price history fallback values are displayed without tax. This occurs in two scenarios:
1. For simple/variable products when there is no price history available within the tracked days and the plugin falls back to the current price in `Prices::handle_old_history()`.
2. For product variations when there is no recorded price history yet and the plugin falls back to the current price in `Variations::add_history()`.
Solution:
- Expose a public `apply_taxes()` wrapper method in `Prices` to delegate tax calculations to the injected `Taxes` helper class.
- Update `Prices::handle_old_history()` to apply taxes to the fallback price before template/custom text rendering.
- Update `Variations::add_history()` to apply taxes to the fallback `$current_price` using the new helper.