### PR TITLE
Fix sale_start empty window using carry-forward effective price

### DIFF
--- a/app/PriorPrice/HistoryStorage.php
+++ b/app/PriorPrice/HistoryStorage.php
@@ -156,8 +156,43 @@ class HistoryStorage {
 		$include_sale_start = ( $count_from === 'sale_start_inclusive' );
 		$cutoff_timestamp   = $sale_start_timestamp - ( $days * DAY_IN_SECONDS );
 
-		$window_prices = [];
-		$older_prices  = [];
+		$candidates = $this->collect_effective_prices_in_sale_window(
+			$history,
+			$cutoff_timestamp,
+			$sale_start_timestamp,
+			$include_sale_start,
+			$wc_product
+		);
+
+		return $this->reduce_to_minimal( $candidates );
+	}
+
+	/**
+	 * Collect effective prices within the sale-start window.
+	 *
+	 * Includes change events inside the window plus carry-forward from the last entry before the window.
+	 *
+	 * @since 3.2.5
+	 *
+	 * @param array<float> $history            Price history keyed by timestamp.
+	 * @param int          $cutoff_timestamp   Window start timestamp.
+	 * @param int          $sale_start_timestamp Window end timestamp.
+	 * @param bool         $include_sale_start Whether the sale start moment is included.
+	 * @param \WC_Product  $wc_product         WC Product.
+	 *
+	 * @return array<float>
+	 */
+	private function collect_effective_prices_in_sale_window(
+		array $history,
+		int $cutoff_timestamp,
+		int $sale_start_timestamp,
+		bool $include_sale_start,
+		\WC_Product $wc_product
+	): array {
+
+		$window_prices          = [];
+		$last_before_cutoff     = null;
+		$last_before_cutoff_key = null;
 
 		foreach ( $history as $timestamp => $price ) {
 			$before_sale_end = $include_sale_start
@@ -169,13 +204,36 @@ class HistoryStorage {
 			}
 
 			if ( $timestamp >= $cutoff_timestamp ) {
-				$window_prices[ $timestamp ] = $price;
-			} else {
-				$older_prices[ $timestamp ] = $price;
+				$window_prices[ $timestamp ] = (float) $price;
+			} elseif ( $last_before_cutoff_key === null || $timestamp > $last_before_cutoff_key ) {
+				$last_before_cutoff_key = $timestamp;
+				$last_before_cutoff     = (float) $price;
 			}
 		}
 
-		return $this->reduce_to_minimal( ! empty( $window_prices ) ? $window_prices : $older_prices );
+		$candidates = array_values( $window_prices );
+
+		if ( $last_before_cutoff !== null ) {
+			$candidates[] = $last_before_cutoff;
+		}
+
+		/**
+		 * Filter candidate prices used to compute the lowest price in the sale-start window.
+		 *
+		 * @since 3.2.5
+		 *
+		 * @param array<float> $candidates Candidate prices.
+		 * @param \WC_Product  $wc_product WC Product.
+		 * @param int          $cutoff_timestamp Window start timestamp.
+		 * @param int          $sale_start_timestamp Window end timestamp.
+		 */
+		return apply_filters(
+			'wc_price_history_sale_start_window_candidates',
+			$candidates,
+			$wc_product,
+			$cutoff_timestamp,
+			$sale_start_timestamp
+		);
 	}
 
 	/**

--- a/app/PriorPrice/HistoryStorage.php
+++ b/app/PriorPrice/HistoryStorage.php
@@ -172,8 +172,6 @@ class HistoryStorage {
 	 *
 	 * Includes change events inside the window plus carry-forward from the last entry before the window.
 	 *
-	 * @since 3.2.5
-	 *
 	 * @param array<float> $history            Price history keyed by timestamp.
 	 * @param int          $cutoff_timestamp   Window start timestamp.
 	 * @param int          $sale_start_timestamp Window end timestamp.
@@ -219,8 +217,6 @@ class HistoryStorage {
 
 		/**
 		 * Filter candidate prices used to compute the lowest price in the sale-start window.
-		 *
-		 * @since 3.2.5
 		 *
 		 * @param array<float> $candidates Candidate prices.
 		 * @param \WC_Product  $wc_product WC Product.

--- a/app/PriorPrice/HistoryStorageTable.php
+++ b/app/PriorPrice/HistoryStorageTable.php
@@ -129,7 +129,16 @@ class HistoryStorageTable {
 			$sale_start_timestamp
 		);
 
-		return (float) min( $candidates );
+		$valid_candidates = array_filter(
+			$candidates,
+			static fn( $price ) => (float) $price > 0
+		);
+
+		if ( empty( $valid_candidates ) ) {
+			return 0.0;
+		}
+
+		return (float) min( $valid_candidates );
 	}
 
 	/**

--- a/app/PriorPrice/HistoryStorageTable.php
+++ b/app/PriorPrice/HistoryStorageTable.php
@@ -114,8 +114,6 @@ class HistoryStorageTable {
 		/**
 		 * Filter candidate prices used to compute the lowest price in the sale-start window.
 		 *
-		 * @since 3.2.5
-		 *
 		 * @param array<float> $candidates Candidate prices.
 		 * @param \WC_Product  $wc_product WC Product.
 		 * @param int          $cutoff_timestamp Window start timestamp.
@@ -575,8 +573,6 @@ class HistoryStorageTable {
 
 	/**
 	 * Query price from the latest history entry before the sale-start window.
-	 *
-	 * @since 3.2.5
 	 *
 	 * @param int    $product_id      Product ID.
 	 * @param string $cutoff_date     Cutoff date (Y-m-d H:i:s UTC).

--- a/app/PriorPrice/HistoryStorageTable.php
+++ b/app/PriorPrice/HistoryStorageTable.php
@@ -93,16 +93,43 @@ class HistoryStorageTable {
 		$end_op     = ( $count_from === 'sale_start_inclusive' ) ? '<=' : '<';
 		$product_id = $wc_product->get_id();
 
-		// Two-step lookup: configured period first, then older history when the window is empty.
-		$result = $this->query_min_price_before_sale_start( $product_id, $cutoff_date, $sale_start_date, $end_op, '>=' );
+		$candidates = [];
 
-		if ( $result !== null ) {
-			return (float) $result;
+		$window_min = $this->query_min_price_before_sale_start( $product_id, $cutoff_date, $sale_start_date, $end_op, '>=' );
+
+		if ( $window_min !== null ) {
+			$candidates[] = (float) $window_min;
 		}
 
-		$fallback = $this->query_min_price_before_sale_start( $product_id, $cutoff_date, $sale_start_date, $end_op, '<' );
+		$carry_forward = $this->query_price_at_last_entry_before_cutoff( $product_id, $cutoff_date, $sale_start_date, $end_op );
 
-		return (float) ( $fallback ?? 0.0 );
+		if ( $carry_forward !== null ) {
+			$candidates[] = (float) $carry_forward;
+		}
+
+		if ( empty( $candidates ) ) {
+			return 0.0;
+		}
+
+		/**
+		 * Filter candidate prices used to compute the lowest price in the sale-start window.
+		 *
+		 * @since 3.2.5
+		 *
+		 * @param array<float> $candidates Candidate prices.
+		 * @param \WC_Product  $wc_product WC Product.
+		 * @param int          $cutoff_timestamp Window start timestamp.
+		 * @param int          $sale_start_timestamp Window end timestamp.
+		 */
+		$candidates = apply_filters(
+			'wc_price_history_sale_start_window_candidates',
+			$candidates,
+			$wc_product,
+			$sale_start_timestamp - ( $days * DAY_IN_SECONDS ),
+			$sale_start_timestamp
+		);
+
+		return (float) min( $candidates );
 	}
 
 	/**
@@ -524,6 +551,52 @@ class HistoryStorageTable {
 				AND date_gmt {$end_op} %s
 				AND include_in_history = 1
 				AND price > 0",
+				$product_id,
+				$cutoff_date,
+				$sale_start_date
+			)
+		);
+
+		if ( $result === null ) {
+			return null;
+		}
+
+		return (string) $result;
+	}
+
+	/**
+	 * Query price from the latest history entry before the sale-start window.
+	 *
+	 * @since 3.2.5
+	 *
+	 * @param int    $product_id      Product ID.
+	 * @param string $cutoff_date     Cutoff date (Y-m-d H:i:s UTC).
+	 * @param string $sale_start_date Sale start date (Y-m-d H:i:s UTC).
+	 * @param string $end_op          Comparison before sale start ('<' or '<=').
+	 *
+	 * @return string|null Price as string, or null when no matching rows.
+	 */
+	private function query_price_at_last_entry_before_cutoff(
+		int $product_id,
+		string $cutoff_date,
+		string $sale_start_date,
+		string $end_op
+	): ?string {
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT price
+				FROM {$wpdb->prefix}wc_price_history
+				WHERE product_id = %d
+				AND date_gmt < %s
+				AND date_gmt {$end_op} %s
+				AND include_in_history = 1
+				AND price > 0
+				ORDER BY date_gmt DESC
+				LIMIT 1",
 				$product_id,
 				$cutoff_date,
 				$sale_start_date

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -306,7 +306,9 @@ For Omnibus-style display, set sale dates in WooCommerce for each discounted pro
 
 When the setting is **Day before product went on sale**, the plugin calculates the lowest price in the configured period before the sale start moment and excludes the promotional price at the sale start.
 
-If that configured period before the sale has no stored price changes (for example, the product was not edited for a long time), the plugin uses the lowest price from older history that is still before the sale start, instead of showing the "no price change" fallback message.
+If there are no price change events inside that window (for example, the product was not edited for a long time), the plugin uses the **last known price before the window** as the effective price for the entire window. It does not fall back to the global minimum from older history outside the window.
+
+If there is no price history at all before the sale start, the plugin uses the **Old history** setting (`hide`, `current price`, or custom text).
 
 If an on-sale product has no sale start date, the plugin falls back to counting from the current day and logs the product in **WooCommerce -> Status -> Logs** with a source starting with `wc-price-history`.
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,7 +133,6 @@ Yes, I am available for hire. Please contact me at [LinkedIn](https://linkedin.c
 == Changelog ==
 
 = {VERSION_ALWAYS_TOP} =
-
 - Fix: When counting from sale start, an empty 30-day pre-sale window now uses the last known price before the window (carry-forward) instead of the global minimum from all older history. (#213)
 
 = 3.2.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,8 @@ Yes, I am available for hire. Please contact me at [LinkedIn](https://linkedin.c
 
 = {VERSION_ALWAYS_TOP} =
 
+- Fix: When counting from sale start, an empty 30-day pre-sale window now uses the last known price before the window (carry-forward) instead of the global minimum from all older history. (#213)
+
 = 3.2.4 =
 - Enhancement: Optional WooCommerce REST API fields `wc_price_history.lowest` and `wc_price_history.history` (settings under WooCommerce → Price History, off by default). (#202)
 - Enhancement: More data in exported JSON file (#195)

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -387,6 +387,7 @@ class HistoryStorageTest extends TestCase {
 			'empty window uses carry-forward price before cutoff' => [ null, '59.99', 59.99, 'sale_start' ],
 			'non-empty window uses min of carry-forward and in-window entries' => [ '59.99', '59.99', 59.99, 'sale_start' ],
 			'in-window drop beats carry-forward' => [ '300.00', '490.00', 300.00, 'sale_start' ],
+			'merchant regression empty window returns stable pre-sale price' => [ null, '490.00', 490.0, 'sale_start' ],
 			'inclusive empty window uses carry-forward price before cutoff' => [ null, '59.99', 59.99, 'sale_start_inclusive' ],
 			'inclusive non-empty window uses min of carry-forward and in-window entries' => [ '49.99', '59.99', 49.99, 'sale_start_inclusive' ],
 			'no pre-sale history returns zero' => [ null, null, 0.0, 'sale_start' ],

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -114,7 +114,7 @@ class HistoryStorageTest extends TestCase {
 	/**
 	 * @dataProvider data_provider_get_minimal_from_sale_start_fallback
 	 */
-	public function test_get_minimal_from_sale_start_falls_back_before_window( $history, $expected_minimal, $count_from ) {
+	public function test_get_minimal_from_sale_start_uses_effective_window_prices( $history, $expected_minimal, $count_from ) {
 
 		$product_id = 1;
 		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
@@ -139,12 +139,12 @@ class HistoryStorageTest extends TestCase {
 	/**
 	 * @dataProvider data_provider_table_get_minimal_from_sale_start_fallback
 	 */
-	public function test_table_get_minimal_from_sale_start_falls_back_before_window( $primary_min_price, $fallback_min_price, $expected_minimal, $count_from ) {
+	public function test_table_get_minimal_from_sale_start_uses_effective_window_prices( $window_min_price, $carry_forward_price, $expected_minimal, $count_from ) {
 
 		$product_id           = 1;
 		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
 
-		$this->mock_table_wpdb_for_sale_start( $primary_min_price, $fallback_min_price );
+		$this->mock_table_wpdb_for_sale_start( $window_min_price, $carry_forward_price );
 		$this->mock_gmt_offset();
 
 		$subject = new HistoryStorageTable();
@@ -192,22 +192,22 @@ class HistoryStorageTest extends TestCase {
 	}
 
 	/**
-	 * @param string|null $primary_min_price  MIN(price) in the sale-start window, or null when empty.
-	 * @param string|null $fallback_min_price MIN(price) before the window, or null when empty.
+	 * @param string|null $window_min_price    MIN(price) in the sale-start window, or null when empty.
+	 * @param string|null $carry_forward_price Price from the latest entry before the window, or null when empty.
 	 */
-	private function mock_table_wpdb_for_sale_start( ?string $primary_min_price, ?string $fallback_min_price ): void {
+	private function mock_table_wpdb_for_sale_start( ?string $window_min_price, ?string $carry_forward_price ): void {
 
 		global $wpdb;
-		$wpdb = new class( $primary_min_price, $fallback_min_price ) {
+		$wpdb = new class( $window_min_price, $carry_forward_price ) {
 			public $prefix = 'wp_';
 
-			private ?string $primary_min_price;
+			private ?string $window_min_price;
 
-			private ?string $fallback_min_price;
+			private ?string $carry_forward_price;
 
-			public function __construct( ?string $primary_min_price, ?string $fallback_min_price ) {
-				$this->primary_min_price   = $primary_min_price;
-				$this->fallback_min_price  = $fallback_min_price;
+			public function __construct( ?string $window_min_price, ?string $carry_forward_price ) {
+				$this->window_min_price    = $window_min_price;
+				$this->carry_forward_price = $carry_forward_price;
 			}
 
 			public function prepare( $query, ...$args ) {
@@ -215,12 +215,12 @@ class HistoryStorageTest extends TestCase {
 			}
 
 			public function get_var( $query ) {
-				if ( stripos( $query, 'date_gmt >=' ) !== false ) {
-					return $this->primary_min_price;
+				if ( stripos( $query, 'SELECT MIN(price)' ) !== false && stripos( $query, 'date_gmt >=' ) !== false ) {
+					return $this->window_min_price;
 				}
 
-				if ( stripos( $query, 'SELECT MIN(price)' ) !== false ) {
-					return $this->fallback_min_price;
+				if ( stripos( $query, 'ORDER BY date_gmt DESC' ) !== false ) {
+					return $this->carry_forward_price;
 				}
 
 				return null;
@@ -272,22 +272,37 @@ class HistoryStorageTest extends TestCase {
 			$sale_start_timestamp => 49.99,
 		];
 
+		$history_with_in_window_drop = [
+			strtotime( '2026-03-30 10:00:00' ) => 490.0,
+			$cutoff_timestamp + DAY_IN_SECONDS => 300.0,
+		];
+
+		$history_merchant_regression = [
+			1715634324 => 149.0,
+			1731793560 => 179.0,
+			1772024266 => 490.0,
+			1774866394 => 490.0,
+		];
+
 		return [
-			'empty window falls back to lowest before cutoff' => [ $history_only_before_window, 44.99, 'sale_start' ],
-			'non-empty window does not use fallback'          => [ $history_with_entry_in_window, 59.99, 'sale_start' ],
-			'inclusive empty window falls back to lowest before cutoff' => [ $history_only_before_window, 44.99, 'sale_start_inclusive' ],
+			'empty window uses carry-forward price before cutoff' => [ $history_only_before_window, 59.99, 'sale_start' ],
+			'non-empty window uses min of carry-forward and in-window entries' => [ $history_with_entry_in_window, 59.99, 'sale_start' ],
+			'inclusive empty window uses carry-forward price before cutoff' => [ $history_only_before_window, 59.99, 'sale_start_inclusive' ],
 			'inclusive entry on sale start day stays in window' => [ $history_with_sale_start_day_entry, 49.99, 'sale_start_inclusive' ],
-			'sale start excludes entry on sale start day' => [ $history_with_sale_start_day_entry, 44.99, 'sale_start' ],
+			'sale start excludes entry on sale start day' => [ $history_with_sale_start_day_entry, 59.99, 'sale_start' ],
+			'in-window drop beats carry-forward' => [ $history_with_in_window_drop, 300.0, 'sale_start' ],
+			'merchant regression empty window returns stable pre-sale price' => [ $history_merchant_regression, 490.0, 'sale_start' ],
 		];
 	}
 
 	public function data_provider_table_get_minimal_from_sale_start_fallback() {
 
 		return [
-			'empty window falls back to lowest before cutoff' => [ null, '44.99', 44.99, 'sale_start' ],
-			'non-empty window does not use fallback'          => [ '59.99', '44.99', 59.99, 'sale_start' ],
-			'inclusive empty window falls back to lowest before cutoff' => [ null, '44.99', 44.99, 'sale_start_inclusive' ],
-			'inclusive non-empty window does not use fallback' => [ '49.99', '44.99', 49.99, 'sale_start_inclusive' ],
+			'empty window uses carry-forward price before cutoff' => [ null, '59.99', 59.99, 'sale_start' ],
+			'non-empty window uses min of carry-forward and in-window entries' => [ '59.99', '59.99', 59.99, 'sale_start' ],
+			'in-window drop beats carry-forward' => [ '300.00', '490.00', 300.00, 'sale_start' ],
+			'inclusive empty window uses carry-forward price before cutoff' => [ null, '59.99', 59.99, 'sale_start_inclusive' ],
+			'inclusive non-empty window uses min of carry-forward and in-window entries' => [ '49.99', '59.99', 49.99, 'sale_start_inclusive' ],
 		];
 	}
 

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -158,6 +158,86 @@ class HistoryStorageTest extends TestCase {
 		$this->assertEquals( $expected_minimal, $minimal );
 	}
 
+	public function test_get_minimal_from_sale_start_returns_zero_when_history_is_empty() {
+
+		$product_id           = 1;
+		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
+
+		$subject = $this->mock_legacy_storage();
+
+		\WP_Mock::userFunction( 'get_post_meta', [
+			'times'  => 1,
+			'args'   => [ $product_id, '_wc_price_history', true ],
+			'return' => [],
+		] );
+
+		\WP_Mock::userFunction( 'wc_get_product', [
+			'times'  => 1,
+			'args'   => [ $product_id ],
+			'return' => null,
+		] );
+
+		$minimal = $subject->get_minimal_from_sale_start(
+			$this->mock_product_with_sale_start( $product_id, $sale_start_timestamp ),
+			30,
+			'sale_start'
+		);
+
+		$this->assertEquals( 0.0, $minimal );
+	}
+
+	public function test_get_minimal_from_sale_start_returns_zero_when_filter_clears_candidates() {
+
+		$product_id           = 1;
+		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
+		$history              = [
+			strtotime( '2025-11-04 01:00:00' ) => 59.99,
+		];
+
+		$subject = $this->mock_legacy_storage();
+
+		\WP_Mock::userFunction( 'get_post_meta', [
+			'times'  => 1,
+			'args'   => [ $product_id, '_wc_price_history', true ],
+			'return' => $history,
+		] );
+
+		\WP_Mock::onFilter( 'wc_price_history_sale_start_window_candidates' )
+			->withAnyArgs()
+			->reply( [] );
+
+		$minimal = $subject->get_minimal_from_sale_start(
+			$this->mock_product_with_sale_start( $product_id, $sale_start_timestamp ),
+			30,
+			'sale_start'
+		);
+
+		$this->assertEquals( 0.0, $minimal );
+	}
+
+	public function test_table_get_minimal_from_sale_start_returns_zero_when_filter_clears_candidates() {
+
+		$product_id           = 1;
+		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
+
+		$this->mock_table_wpdb_for_sale_start( null, '59.99' );
+		$this->mock_gmt_offset();
+
+		\WP_Mock::onFilter( 'wc_price_history_sale_start_window_candidates' )
+			->withAnyArgs()
+			->reply( [] );
+
+		$subject = new HistoryStorageTable();
+
+		$minimal = $subject->get_minimal_from_sale_start(
+			$this->mock_product_with_sale_start( $product_id, $sale_start_timestamp ),
+			30,
+			'sale_start'
+		);
+
+		$this->assertEquals( 0.0, $minimal );
+	}
+
 	private function mock_legacy_storage(): HistoryStorage {
 
 		$this->mock_legacy_storage_options();
@@ -284,6 +364,10 @@ class HistoryStorageTest extends TestCase {
 			1774866394 => 490.0,
 		];
 
+		$history_only_after_sale_start = [
+			$sale_start_timestamp + ( 2 * DAY_IN_SECONDS ) => 49.99,
+		];
+
 		return [
 			'empty window uses carry-forward price before cutoff' => [ $history_only_before_window, 59.99, 'sale_start' ],
 			'non-empty window uses min of carry-forward and in-window entries' => [ $history_with_entry_in_window, 59.99, 'sale_start' ],
@@ -292,6 +376,8 @@ class HistoryStorageTest extends TestCase {
 			'sale start excludes entry on sale start day' => [ $history_with_sale_start_day_entry, 59.99, 'sale_start' ],
 			'in-window drop beats carry-forward' => [ $history_with_in_window_drop, 300.0, 'sale_start' ],
 			'merchant regression empty window returns stable pre-sale price' => [ $history_merchant_regression, 490.0, 'sale_start' ],
+			'no pre-sale history returns zero' => [ $history_only_after_sale_start, 0.0, 'sale_start' ],
+			'inclusive no pre-sale history returns zero' => [ $history_only_after_sale_start, 0.0, 'sale_start_inclusive' ],
 		];
 	}
 
@@ -303,6 +389,8 @@ class HistoryStorageTest extends TestCase {
 			'in-window drop beats carry-forward' => [ '300.00', '490.00', 300.00, 'sale_start' ],
 			'inclusive empty window uses carry-forward price before cutoff' => [ null, '59.99', 59.99, 'sale_start_inclusive' ],
 			'inclusive non-empty window uses min of carry-forward and in-window entries' => [ '49.99', '59.99', 49.99, 'sale_start_inclusive' ],
+			'no pre-sale history returns zero' => [ null, null, 0.0, 'sale_start' ],
+			'inclusive no pre-sale history returns zero' => [ null, null, 0.0, 'sale_start_inclusive' ],
 		];
 	}
 

--- a/tests/phpunit/HistoryStorageTest.php
+++ b/tests/phpunit/HistoryStorageTest.php
@@ -112,7 +112,7 @@ class HistoryStorageTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider data_provider_get_minimal_from_sale_start_fallback
+	 * @dataProvider data_provider_get_minimal_from_sale_start_uses_effective_window_prices
 	 */
 	public function test_get_minimal_from_sale_start_uses_effective_window_prices( $history, $expected_minimal, $count_from ) {
 
@@ -137,7 +137,7 @@ class HistoryStorageTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider data_provider_table_get_minimal_from_sale_start_fallback
+	 * @dataProvider data_provider_table_get_minimal_from_sale_start_uses_effective_window_prices
 	 */
 	public function test_table_get_minimal_from_sale_start_uses_effective_window_prices( $window_min_price, $carry_forward_price, $expected_minimal, $count_from ) {
 
@@ -334,7 +334,7 @@ class HistoryStorageTest extends TestCase {
 		return $product;
 	}
 
-	public function data_provider_get_minimal_from_sale_start_fallback() {
+	public function data_provider_get_minimal_from_sale_start_uses_effective_window_prices() {
 
 		$sale_start_timestamp = strtotime( '2026-06-18 00:00:00' );
 		$cutoff_timestamp     = $sale_start_timestamp - ( 30 * DAY_IN_SECONDS );
@@ -381,7 +381,7 @@ class HistoryStorageTest extends TestCase {
 		];
 	}
 
-	public function data_provider_table_get_minimal_from_sale_start_fallback() {
+	public function data_provider_table_get_minimal_from_sale_start_uses_effective_window_prices() {
 
 		return [
 			'empty window uses carry-forward price before cutoff' => [ null, '59.99', 59.99, 'sale_start' ],


### PR DESCRIPTION
## Summary

Fixes #213.

When `count_from` is `sale_start` / `sale_start_inclusive` and the configured pre-sale window has **no price change events**, the plugin no longer falls back to `MIN(price)` from all older history. Instead it uses **carry-forward**: the last known price before the window start, combined with any in-window change events.

This fixes incorrect Omnibus lowest prices (e.g. showing 149 PLN from two years ago while the product was 490 PLN for months before the promotion).

## Changes

- **`HistoryStorage`**: new `collect_effective_prices_in_sale_window()` — window entries + carry-forward candidate, then `MIN()`.
- **`HistoryStorageTable`**: same semantics via `query_price_at_last_entry_before_cutoff()` (latest entry before cutoff) combined with existing in-window `MIN()` query.
- **Filter**: `wc_price_history_sale_start_window_candidates` for extensibility.
- **Tests**: updated expectations from #208 behaviour; added in-window drop and merchant regression cases.
- **Docs**: updated `user-manual.md` and `readme.txt` changelog.

## Behaviour examples

| Scenario | Before (#208) | After |
|----------|---------------|-------|
| Empty window, stable 490 PLN for months | 149 PLN (global min) | 490 PLN (carry-forward) |
| Empty window, last price 59.99 | 44.99 (global min) | 59.99 (carry-forward) |
| Carry-forward 490 + in-window 300 | N/A | 300 |
| No history before sale | 0 → `old_history` | unchanged |

## Test plan

- [x] `vendor/bin/phpunit` — all 21 tests pass
- [x] `vendor/bin/phpstan analyse -c phpstan.neon` — no errors
- [ ] Manual: on-sale product with stable price and no edits in last 30 pre-sale days shows last known price, not ancient minimum
- [ ] Manual: product with price drop inside the window shows correct minimum including carry-forward period