### PR TITLE
WPML: translate minimal price text on frontend

### DIFF
--- a/app/PriorPrice/SettingsData.php
+++ b/app/PriorPrice/SettingsData.php
@@ -50,10 +50,13 @@ class SettingsData {
 		}
 
 		// Handle settings added in 1.3.
-		if ( ! isset( $settings['display_text'] ) || $settings['display_text'] === '30-day low: %s' ) {
+		if ( ! isset( $settings['display_text'] ) ) {
 			/* translators: %s - the lowest price in the last 30 days. */
 			$old_format = esc_html__( '30-day low: %s', 'wc-price-history' );
 			$settings['display_text'] = str_replace( [ '30', '%s' ], [ '{days}', '{price}' ], $old_format );
+			$update                   = true;
+		} elseif ( is_string( $settings['display_text'] ) && strpos( $settings['display_text'], '%s' ) !== false && strpos( $settings['display_text'], '{price}' ) === false ) {
+			$settings['display_text'] = str_replace( '%s', '{price}', $settings['display_text'] );
 			$update                   = true;
 		}
 

--- a/app/PriorPrice/SettingsData.php
+++ b/app/PriorPrice/SettingsData.php
@@ -51,8 +51,9 @@ class SettingsData {
 
 		// Handle settings added in 1.3.
 		if ( ! isset( $settings['display_text'] ) || $settings['display_text'] === '30-day low: %s' ) {
-			/* translators: Do not translate {price}, it is template slug! */
-			$settings['display_text'] = esc_html__( '30-day low: {price}', 'wc-price-history' );
+			/* translators: %s - the lowest price in the last 30 days. */
+			$old_format = esc_html__( '30-day low: %s', 'wc-price-history' );
+			$settings['display_text'] = str_replace( [ '30', '%s' ], [ '{days}', '{price}' ], $old_format );
 			$update                   = true;
 		}
 
@@ -193,8 +194,9 @@ class SettingsData {
 
 		$settings = get_option( 'wc_price_history_settings' );
 		if ( ! isset( $settings['display_text'] ) ) {
-			/* translators: Do not translate {price}, it is template slug! */
-			return esc_html__( '30-day low: {price}', 'wc-price-history' );
+			/* translators: %s - the lowest price in the last 30 days. */
+			$old_format = esc_html__( '30-day low: %s', 'wc-price-history' );
+			return str_replace( [ '30', '%s' ], [ '{days}', '{price}' ], $old_format );
 		}
 		return esc_html( $settings['display_text'] );
 	}

--- a/app/PriorPrice/SettingsData.php
+++ b/app/PriorPrice/SettingsData.php
@@ -193,10 +193,8 @@ class SettingsData {
 
 		$settings = get_option( 'wc_price_history_settings' );
 		if ( ! isset( $settings['display_text'] ) ) {
-			/* translators: %s - the lowest price in the last 30 days. */
-			$old_format = esc_html__( '30-day low: %s', 'wc-price-history' );
-			$with_placeholders = str_replace( [ '30', '%s' ], [ '{days}', '{price}' ], $old_format );
-			return $with_placeholders;
+			/* translators: Do not translate {price}, it is template slug! */
+			return esc_html__( '30-day low: {price}', 'wc-price-history' );
 		}
 		return esc_html( $settings['display_text'] );
 	}

--- a/app/PriorPrice/SettingsPage.php
+++ b/app/PriorPrice/SettingsPage.php
@@ -288,7 +288,7 @@ class SettingsPage {
 												name="wc_price_history_settings[display_text]"
 												class="wc-price-history-wide-field"
 												<?php /* translators: Do not translate {price}, it is template slug! */ ?>
-												value="<?php echo isset( $settings['display_text'] ) ? esc_html( $settings['display_text'] ) : esc_html__( '30-day low: {price}', 'wc-price-history' ); ?>"
+												value="<?php echo isset( $settings['display_text'] ) ? esc_attr( $settings['display_text'] ) : esc_attr__( '30-day low: {price}', 'wc-price-history' ); ?>"
 											/>
 										</label>
 									</p>
@@ -358,7 +358,7 @@ class SettingsPage {
 												name="wc_price_history_settings[old_history_custom_text]"
 												class="wc-price-history-wide-field"
 												<?php /* translators: Do not translate {days}, it is template slug! */ ?>
-												value="<?php echo isset( $settings['old_history_custom_text'] ) ? esc_html( $settings['old_history_custom_text'] ) : esc_html__( 'Price in the last {days} days is the same as current', 'wc-price-history' ); ?>"
+												value="<?php echo isset( $settings['old_history_custom_text'] ) ? esc_attr( $settings['old_history_custom_text'] ) : esc_attr__( 'Price in the last {days} days is the same as current', 'wc-price-history' ); ?>"
 											/>
 										</label>
 									</p>

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -2,6 +2,7 @@
 	<admin-texts>
 		<key name="wc_price_history_settings">
 			<key name="display_text" />
+			<key name="old_history_custom_text" />
 			<key name="variable_product_defer_placeholder_text" />
 		</key>
 	</admin-texts>


### PR DESCRIPTION
Fix WPML String Translation not showing the translated "Minimal price text" because `SettingsData::get_display_text()` fell back to a legacy msgid (`30-day low: %s`). The fallback now uses the modern msgid (`30-day low: {price}`) so WPML can supply the correct translation.

Also add `old_history_custom_text` to `wpml-config.xml` to keep WPML option translation coverage consistent.

Refs: #218